### PR TITLE
mxfb-appfinder fixes and gkrellm config edits

### DIFF
--- a/base-mxfb/bin/app-categories
+++ b/base-mxfb/bin/app-categories
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-ACCESS="Accesories"
+ACCESS="Accessories"
 OFFICE="Office"
 GRAPH="Graphics"
 GAMES="Games"
@@ -12,93 +12,93 @@ DEVPMNT="Development"
 SYSTM="System"
 ALLAPPS="ALL APPS"
 
-ACCESSi="  $ACCESS"
-OFFICEi="  $OFFICE"
-GRAPHi="  $GRAPH"
-GAMESi="  $GAMES"
-INETi="  $INET"
-MMEDIAi="  $MMEDIA"
-MXTOOLSi="  $MXTOOLS"
-SETTGSi="  $SETTGS"
-DEVPMNTi="  $DEVPMNT"
-SYSTMi="  $SYSTM"
-ALLAPPSi="  Apps"
+ACCESSi=""
+OFFICEi=""
+GRAPHi=""
+GAMESi=""
+INETi=""
+MMEDIAi=""
+MXTOOLSi=""
+SETTGSi=""
+DEVPMNTi=""
+SYSTMi=""
+ALLAPPSi=""
 
 if [ x"$@" = x"$ALLAPPS" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "" -display-drun  "$ALLAPPSi"
+rofi -show drun  -drun-categories "" -display-drun  "$ALLAPPSi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$ACCESS" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Utility,Accessories" -display-drun "$ACCESSi"
+rofi -show drun  -drun-categories "Utility,Accessories" -display-drun "$ACCESSi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$OFFICE" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Office,TextEditor" -display-drun "$OFFICEi"
+rofi -show drun  -drun-categories "Office,TextEditor" -display-drun "$OFFICEi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$GRAPH" ];
 then
 killall rofi
-sleep 0.25
-rofi -show drun  -drun-categories "Graphics,Image,Photo" -display-drun "$GRAPHi"
+sleep 0.25 
+rofi -show drun -drun-categories "Graphics,Image,Photo" -display-drun "$GRAPHi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$GAMES" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Game" -display-drun "$GAMESi"
+rofi -show drun  -drun-categories "Game" -display-drun "$GAMESi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$INET" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Network,WebBrowser" -display-drun "$INETi"
+rofi -show drun  -drun-categories "Network,WebBrowser" -display-drun "$INETi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$MMEDIA" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Music,Sound,Video,Audio,AudioVideo,Multimedia" -display-drun "$MMEDIAi"
+rofi -show drun  -drun-categories "Music,Sound,Video,Audio,AudioVideo,Multimedia" -display-drun "$MMEDIAi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$MXTOOLS" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "MX-Setup,MX-Maintenance,MX-Software,MX-Utilities,MX-Live" -display-drun "$MXTOOLSi"
+rofi -show drun  -drun-categories "MX-Setup,MX-Maintenance,MX-Software,MX-Utilities,MX-Live" -display-drun "$MXTOOLSi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$SETTGS" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories  "Settings" -display-drun "$SETTGSi"
+rofi -show drun  -drun-categories  "Settings" -display-drun "$SETTGSi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$DEVPMNT" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "Development,TerminalEmulator"  -display-drun "$DEVPMNTi"
+rofi -show drun  -drun-categories "Development,TerminalEmulator"  -display-drun "$DEVPMNTi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 if [ x"$@" = x"$SYSTM" ];
 then
 killall rofi
 sleep 0.25
-rofi -show drun  -drun-categories "System" -display-drun "$SYSTMi"
+rofi -show drun  -drun-categories "System" -display-drun "$SYSTMi" -theme ~/.config/rofi/themes/mxfb-appfinder/mxfb-appfinder.rasi
 fi
 
 echo -e "$ALLAPPS\0icon\x1fapplications-all"

--- a/mx/etc/skel/.config/rofi/themes/appfinder/mxfb-appfinder.rasi
+++ b/mx/etc/skel/.config/rofi/themes/appfinder/mxfb-appfinder.rasi
@@ -1,5 +1,5 @@
 configuration {
-modi: ":/usr/bin/app-categories,drun,window,help:/usr/share/rofi/rofi-help";
+modi: "drun,:/usr/bin/app-categories,window,help:/usr/share/rofi/rofi-help";
 }
-
+@import "/mxrm-settings/display0.rasi"
 @theme "~/.config/rofi/themes/appfinder/mxfb-appfinder-config.rasi"

--- a/mx/etc/skel/.gkrellm2/theme_config
+++ b/mx/etc/skel/.gkrellm2/theme_config
@@ -1,6 +1,6 @@
-/home/jb/.gkrellm2/themes/MonkeyLovers_fb
+/home/jb/.gkrellm2/themes/MX-comfort-dark
 0
-Serif 11
-Serif 9
-Serif 8
+Noto Sans 11
+Noto Sans 9
+Noto Sans 8
 100

--- a/mx/etc/skel/.gkrellm2/user-config
+++ b/mx/etc/skel/.gkrellm2/user-config
@@ -2,7 +2,7 @@
 ### Version 2.3.10 ###
 enable_hostname 0
 hostname_short 0
-enable_sysname 1
+enable_sysname 0
 mbmon_port 0
 sticky_state 1
 dock_type 0
@@ -27,9 +27,9 @@ clock_cal hour_chime_command
 clock_cal quarter_chime_command 
 clock_cal loop_chime_enable 0
 clock_cal clock_options 1
-clock_cal cal_options 1
-clock_cal cal_format %a <span foreground="cyan2"><span font_desc="16.5"><i>%e</i></span></span> %b
-clock_cal clock_format %l:%M <span foreground="$A"><small>%S</small></span>
+clock_cal cal_options 0
+clock_cal cal_format %a <span foreground="$A"><big><big>%e</big></big></span> %b
+clock_cal clock_format %H:%M   %a %e %b
 cpu enable 0
 cpu smp_mode 0
 cpu enabled cpu 1


### PR DESCRIPTION
mxfb-appfinder
categories now opens as filtered list in appfinder, no longer in separate rofi window

gkrellm
config edits to MX-comfort-dark
Still need to find a way to change the path in theme_config from default
/home/jb/.gkrellm2/themes/MX-comfort-dark to /home/USERNAME/.gkrellm2/themes/MX-comfort-dark. Unfortunately ~/ $HOME/ or /home/$USER/ don't work.
